### PR TITLE
Revert "open github issue on regression failure (#2248)"

### DIFF
--- a/.github/workflows/regression_tests_cpu.yml
+++ b/.github/workflows/regression_tests_cpu.yml
@@ -32,11 +32,3 @@ jobs:
       - name: Torchserve Regression Tests
         run: |
           python test/regression_tests.py
-      - name: Open issue on failure
-        if: ${{ failure() && github.event_name  == 'schedule' }}
-        uses: dacbd/create-issue-action@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          title: CPU Regression tests failed
-          body:  Commit ${{ github.sha }} daily scheduled [${{ github.workflow }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) failed, please check why
-          assignees: ''

--- a/.github/workflows/regression_tests_gpu.yml
+++ b/.github/workflows/regression_tests_gpu.yml
@@ -44,11 +44,3 @@ jobs:
       - name: Torchserve Regression Tests
         run: |
           python test/regression_tests.py
-      - name: Open issue on failure
-        if: ${{ failure() && github.event_name  == 'schedule' }}
-        uses: dacbd/create-issue-action@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          title: CPU Regression tests failed
-          body:  Commit ${{ github.sha }} daily scheduled [${{ github.workflow }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) failed, please check why
-          assignees: ''


### PR DESCRIPTION
### Description

In this pull request, changes have been made to the GitHub Actions workflows for regression tests on CPU and GPU environments. The section responsible for opening an issue on failure has been removed from both workflows.

- Removed the step for opening an issue on failure from both the CPU and GPU regression test workflows.