### PR TITLE
fix: kubernetes/kserve/image_transformer/transformer.Dockerfile to re…

### DIFF
--- a/kubernetes/kserve/image_transformer/transformer.Dockerfile
+++ b/kubernetes/kserve/image_transformer/transformer.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.18-slim
+FROM python:3.13.0a3-slim
 ARG BRANCH_NAME_KF=master
 
 RUN apt-get update \


### PR DESCRIPTION
### Description

The Dockerfile for the image transformer in the kServe project is being updated to use a newer version of the base Python image.

Changes:
- Update base Python image from `python:3.8.18-slim` to `python:3.13.0a3-slim`.

These changes are being made to leverage the newer Python version and potentially include any additional features or improvements provided in the updated base image.